### PR TITLE
Bump remaining conflicting Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,7 @@ natsort==7.0.1
 nbconvert==6.5.1
 nbformat==5.0.4
 notebook==6.4.12
-numpy==1.18.1
+numpy==1.22.0
 oauthlib==3.1.0
 opt-einsum==3.1.0
 packaging==20.4
@@ -126,9 +126,9 @@ ptyprocess==0.6.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.19
-pydantic==1.5.1
+pydantic==1.6.2
 Pygments==2.7.4
-PyJWT==1.7.1
+PyJWT==2.4.0
 pyparsing==2.4.6
 pyrsistent==0.15.7
 python-daemon==2.2.4


### PR DESCRIPTION
## Summary

Applies the three remaining Dependabot security bumps that were left conflicted after merging the clean Dependabot queue:

- numpy: 1.18.1 -> 1.22.0
- pydantic: 1.5.1 -> 1.6.2
- PyJWT: 1.7.1 -> 2.4.0

This supersedes the stale conflicting Dependabot PRs #17, #40, and #42.

## Verification

- Confirmed requirements.txt contains the target versions from the three Dependabot PRs.
- Commit signed with the new batchprocess128 Codex SSH signing key.